### PR TITLE
Feat: 默认隐藏功能按钮，完成捕获后不提示

### DIFF
--- a/media-source-extract.user.js
+++ b/media-source-extract.user.js
@@ -6,6 +6,8 @@
 // @author       Momo707577045
 // @include      *
 // @exclude      http://blog.luckly-mjw.cn/tool-show/media-source-extract/player/player.html
+// @downloadURL	 https://github.com/Momo707577045/media-source-extract/blob/master/media-source-extract.user.js
+// @updateURL	 https://github.com/Momo707577045/media-source-extract/blob/master/media-source-extract.user.js
 // @grant        none
 // @run-at document-start
 // ==/UserScript==

--- a/media-source-extract.user.js
+++ b/media-source-extract.user.js
@@ -17,8 +17,9 @@
       return
     }
 
-    let isClose = false
+    let isClose = true
     let _sourceBufferList = []
+    let $showBtn = document.createElement('div') // 展示按钮
     let $btnDownload = document.createElement('div')
     let $downloadNum = document.createElement('div')
     let $tenRate = document.createElement('div') // 十倍速播放
@@ -88,9 +89,17 @@
     let _endOfStream = window.MediaSource.prototype.endOfStream
     window.MediaSource.prototype.endOfStream = function() {
       if (!isClose) {
-        alert('资源全部捕获成功，即将下载！')
-        _download()
+        // alert('资源全部捕获成功，即将下载！')
+        let text = '资源全部捕获成功，即将下载！';
+        if (confirm(text) == true) {
+          _download()
+        } else {
+          // 不下载资源
+        }
         _endOfStream.call(this)
+      } else {
+        // closed
+        _sourceBufferList = []  //这里新增的
       }
     }
 
@@ -144,6 +153,8 @@
       $tenRate.style = baseStyle + `top: 150px;`
       $btnDownload.style = baseStyle + `top: 100px;`
       $downloadNum.style = baseStyle
+      $showBtn.innerHTML = '展示捕获面板'
+      $showBtn.style = baseStyle + `top: 250px;`
       $closeBtn.style = `
         position: fixed;
         top: 200px;
@@ -152,20 +163,36 @@
         z-index: 9999;
         cursor: pointer;
       `
+      $btnDownload.style.display = 'none'
+      $closeBtn.style.display = 'none'
+      $tenRate.style.display = 'none'
+
       $btnDownload.addEventListener('click', _download)
       $tenRate.addEventListener('click', _tenRatePlay)
       $closeBtn.addEventListener('click', function() {
-        $btnDownload.remove()
-        $downloadNum.remove()
-        $closeBtn.remove()
-        $tenRate.remove()
+        // $btnDownload.remove()
+        // $downloadNum.remove()
+        // $closeBtn.remove()
+        // $tenRate.remove()
+        $btnDownload.style.display = 'none'
+        $closeBtn.style.display = 'none'
+        $tenRate.style.display = 'none'
+        $showBtn.style.display = 'block'
         isClose = true
+      })
+      $showBtn.addEventListener('click', function() {
+        $btnDownload.style.display = 'block'
+        $closeBtn.style.display = 'block'
+        $tenRate.style.display = 'block'
+        $showBtn.style.display = 'none'
+        isClose = false
       })
 
       document.getElementsByTagName('html')[0].insertBefore($tenRate, document.getElementsByTagName('head')[0]);
       document.getElementsByTagName('html')[0].insertBefore($downloadNum, document.getElementsByTagName('head')[0]);
       document.getElementsByTagName('html')[0].insertBefore($btnDownload, document.getElementsByTagName('head')[0]);
       document.getElementsByTagName('html')[0].insertBefore($closeBtn, document.getElementsByTagName('head')[0]);
+      document.getElementsByTagName('html')[0].insertBefore($showBtn, document.getElementsByTagName('head')[0]);
     }
 
 

--- a/media-source-extract.user.js
+++ b/media-source-extract.user.js
@@ -156,7 +156,7 @@
       $btnDownload.style = baseStyle + `top: 100px;`
       $downloadNum.style = baseStyle
       $showBtn.innerHTML = '展示捕获面板'
-      $showBtn.style = baseStyle + `top: 250px;`
+      $showBtn.style = baseStyle + `top: 100px;`
       $closeBtn.style = `
         position: fixed;
         top: 200px;

--- a/media-source-extract.user.js
+++ b/media-source-extract.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         media-source-extract
 // @namespace    https://github.com/Momo707577045/media-source-extract
-// @version      0.2
+// @version      0.3
 // @description  https://github.com/Momo707577045/media-source-extract 配套插件
 // @author       Momo707577045
 // @include      *


### PR DESCRIPTION
Feature:
1. 默认隐藏功能面板 isClose = true
2. 增加展示面板的按钮
3. 调整捕获完成的提示方式，调整成confirm。如果取消则不进行下载
4. 调整按钮隐藏的方式
5. 配置脚本更新拉取地址

调整背景：
在搜索中打开了百度百科，一会就提示视频捕获完成，并且无法取消，导致经常下载一些无用的视频文件。